### PR TITLE
Substituir o Mysql pelo H2 embedded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-    </dependency>
+	  <groupId>com.h2database</groupId>
+	  <artifactId>h2</artifactId>
+	</dependency>	
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,10 +1,7 @@
 #spring boot properties
 #Thu Jul 21 15:01:47 EDT 2016
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.username=bb0d27ab7f71b7
-spring.datasource.password=a09be75e
-spring.datasource.url=jdbc:mysql://us-cdbr-iron-east-04.cleardb.net/heroku_f9aad0e6d5fd543?reconnect=true
-spring.jpa.hibernate.ddl-auto=update
-spring.datasource.connection-test-query="SELECT 1"
-spring.datasource.test-while-idle=true
-spring.datasource.test-on-borrow=true
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,7 @@
 #spring boot properties
 #Thu Jul 21 15:01:47 EDT 2016
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.username=root
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
 spring.datasource.password=
-spring.datasource.url=jdbc:mysql://localhost/cdc_react?createDatabaseIfNotExist=true
-spring.jpa.hibernate.ddl-auto=update
-spring.datasource.connection-test-query="SELECT 1"
-spring.datasource.test-while-idle=true
-spring.datasource.test-on-borrow=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Para não existir a necessidade do aluno subir o mysql local.
O que acha de substituir o mysql pelo H2 embedded?

* Alterei a dependência do mysql pela do H2;
* Alterei os arquivos application.properties e application-production.properties;

Espero ter ajudado!

